### PR TITLE
flex-devel rpm needed for gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install flex and yacc in Ubuntu:
 
 To install flex and yacc in Fedora:
 
-* __sudo yum install flex__
+* __sudo yum install flex flex-devel__
 * __sudo yum install bison__
 
 Steps to execute the project:


### PR DESCRIPTION
If gcc throws this error, flex-devel is needed:
/usr/bin/ld: cannot find -ly